### PR TITLE
feat: include ci workflow for prettier

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,0 +1,26 @@
+name: 'Format Code'
+on:
+  push:
+    branches:
+      - main
+jobs:
+  format:
+    name: Prettier
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [18]
+    steps:
+      - uses: actions/checkout@v3
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 8
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: "pnpm"
+      - name: Install dependencies
+        run: pnpm install
+      - name: Formatting with Prettier
+        run: pnpm format:ci

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,0 @@
-{
-  "editor.defaultFormatter": "esbenp.prettier-vscode",
-  "editor.formatOnSave": true
-}

--- a/package.json
+++ b/package.json
@@ -1,14 +1,15 @@
 {
   "name": "website",
   "type": "module",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "scripts": {
     "dev": "astro dev",
     "start": "astro dev",
     "build": "astro check && astro build",
     "preview": "astro preview",
     "astro": "astro",
-    "format": "prettier . -w --cache"
+    "format": "prettier . -w --cache",
+    "format:ci": "prettier ./src/ -w"
   },
   "dependencies": {
     "@astrojs/check": "^0.8.3",


### PR DESCRIPTION
- removes enforced vscode settings
- `format.yml` configured to prettify on push to `main`